### PR TITLE
Python done proper like

### DIFF
--- a/scm-scripts/git-serve.py
+++ b/scm-scripts/git-serve.py
@@ -14,15 +14,17 @@
 # @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
 # 
 import os
+import os.path
 import sys
-import commands
-import traceback
+import subprocess
+import shlex
 
-CAKE = traceback.extract_stack(limit=1)[0][0][0:-len("/scm-scripts/git-serve.py")]
-GITSERVEPHP = '%s/app/Console/cake -app %s/app/ git serve' % (CAKE, CAKE)
-status, output = commands.getstatusoutput('%s %s' % (GITSERVEPHP, sys.argv[1]))
-if status == 0:
-    os.execvp('git', ['git', 'shell', '-c', output.strip()])
-else:
-    sys.stderr.write("%s\n" % output)
-sys.exit(1)
+# XXX: There are probably better ways of pulling the parent directory
+# but I really didn't want to deal with os.path.split
+CAKE_ROOT = os.path.abspath(os.path.dirname(__file__) + '/../')
+GITSERVEPHP = '{0}/app/Console/cake -app {0}/app/ git serve {1}'.format(CAKE_ROOT, sys.argv[1])
+try:
+    output = subprocess.check_output(shlex.split(GITSERVEPHP))
+    subprocess.check_output(['git-shell', '-c', output.strip()])
+except subprocess.CalledProcessError:
+    sys.exit(1)


### PR DESCRIPTION
Changed calls to older exec functions to use the shiny `subprocess` module.
Stopped abusing traceback to find the path of the currently executing script.

_NOTE:_ These changes haven't been tested in a real environment. Test throughly before merging.
